### PR TITLE
Add Claude Code plugin support

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "symfony-ux",
+  "version": "1.0.0",
+  "description": "AI agent skills for the Symfony UX frontend stack: Stimulus, Turbo, TwigComponent, and LiveComponent.",
+  "author": {
+    "name": "Simon Andre",
+    "email": "smn.andre@gmail.com",
+    "url": "https://smnandre.dev"
+  },
+  "homepage": "https://github.com/smnandre/symfony-ux-skills",
+  "repository": "https://github.com/smnandre/symfony-ux-skills",
+  "license": "MIT",
+  "keywords": [
+    "symfony",
+    "ux",
+    "stimulus",
+    "turbo",
+    "twig-component",
+    "live-component",
+    "php"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Optional entry-point files for your project root. They provide a quick decision 
 
 ```
 .
+├── .claude-plugin/
+│   └── plugin.json
 ├── README.md
 ├── LICENSE
 ├── CLAUDE.md
@@ -72,7 +74,19 @@ Optional entry-point files for your project root. They provide a quick decision 
 
 ## Installation
 
-### 1. Install the skills
+### Claude Code Plugin (recommended)
+
+This repository is installable as a [Claude Code plugin](https://code.claude.com/docs/en/plugins). Skills are automatically discovered and namespaced under `symfony-ux:`.
+
+```bash
+# Test locally
+claude --plugin-dir /path/to/symfony-ux-skills
+
+# Or install from a marketplace (if available)
+claude plugin install symfony-ux
+```
+
+### Manual installation
 
 Copy each skill directory into the skills location for your platform.
 


### PR DESCRIPTION
## Summary

- Add `.claude-plugin/plugin.json` manifest so the repository can be installed as a Claude Code plugin (requires v1.0.33+)
- Skills from the existing `skills/` directory are auto-discovered and namespaced under `symfony-ux:`
- Update README with plugin installation instructions (alongside existing manual install)

## Usage

```bash
# Test locally
claude --plugin-dir /path/to/symfony-ux-skills

# Or install from a marketplace (if available)
claude plugin install symfony-ux
```

## Details

The plugin manifest follows the [Claude Code plugin specification](https://code.claude.com/docs/en/plugins). No changes to existing skills or other platform files (AGENTS.md, GEMINI.md, gemini-extension.json) — this is purely additive.